### PR TITLE
Create c-5c.ks

### DIFF
--- a/Texte/Clean/c-5c.ks
+++ b/Texte/Clean/c-5c.ks
@@ -1,0 +1,10 @@
+﻿*page0|
+　L'un avait la vitesse d'un ouragan, mais l'autre était rapide comme l'éclair.
+　Si dans sa charge, le loup-garou évoquait une ombre sinistre, alors le jeune homme qui lui tenait tête s'apparentait à une ombre noire silencieuse.
+　La position qu'il devait occuper se trouvait exactement à trois pas.
+　Il misa tout son être dans cette avancée d'à peine un mètre.
+*page1|
+「――――――」
+　この世のものとは思えない結末に、当事者以外の誰もが目を疑う。
+　それを一身に受けながら、人狼を見下ろしているのは言うまでもなく、静希草十郎という名前の、ごく当たり前の少年だった。
+*page2|


### PR DESCRIPTION
`c-5c.ks` est le seul `.ks` présent dans `Raw` mais pas dans `Clean`. Il ne comporte pas beaucoup de lignes et elles ressemblent à celles de `c-5b.ks`. Certaines phrases sont identiques.
Personne n'a l'air de s'être plaint de textes en japonais donc j'imagine que le jeu ne les affiche pas.
Par souci de cohérence je l'ajoute quand même. Le script Steam (et console aussi certainement) demande ces lignes.

Pour le début il y a une phrase différente
`c-5b`
> 弾け跳んだ人狼が黒影なら、迎え撃たんと踏みこむ彼も無音の影。

Traduit par  
> Si dans sa charge, le loup-garou évoquait une ombre sinistre, alors le jeune homme qui lui tenait tête s'apparentait à une ombre silencieuse.

`c-5c`
> 弾け跳んだ人狼が黒影なら、迎え撃たんと踏みこむ彼も無音の黒影。

Si j'en crois deepl, la modification est une précision de la couleur de l'ombre "à une ombre noire silencieuse.". **J'ai ajouté**.


Pour les deux dernières, elles ressemblent à la fin du `c-5b` mais sont différentes. **Je n'ai pas traduit**.
`c-5b`
> この世のものとは思えない結末に誰もが目を疑う。
> 当事者は呼吸さえ乱さず、淡々と、倒れ臥した人狼を見下ろしていた。

`c-5c`
> この世のものとは思えない結末に、当事者以外の誰もが目を疑う。
> それを一身に受けながら、人狼を見下ろしているのは言うまでもなく、静希草十郎という名前の、ごく当たり前の少年だった。